### PR TITLE
Update requirements.txt to include missing dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ cvxopt>=1.2.5
 cvxpy>=1.1.7
 lxml>=4.6.3
 fastkml>=0.11
+gurobipy>=10.0.3


### PR DESCRIPTION
When installing from source and running ```examples/stanford.py```, I ran into the following issue:

```
bullding pathGraph
linking routes
The solver GUROBI is not installed.
cvx timeout for 8 groups
The solver GUROBI is not installed.
cvx timeout for 9 groups
The solver GUROBI is not installed.
cvx timeout for 10 groups
The solver GUROBI is not installed.
cvx timeout for 11 groups
The solver GUROBI is not installed.
cvx timeout for 12 groups
The solver GUROBI is not installed.
cvx timeout for 13 groups
The solver GUROBI is not installed.
cvx timeout for 14 groups
The solver GUROBI is not installed.
cvx timeout for 15 groups
The solver GUROBI is not installed.
```

Running ```pip install gurobipy``` solved the issue.